### PR TITLE
sepolicy: Unlabel camera privapp whitelist prop

### DIFF
--- a/qva/private/property_contexts
+++ b/qva/private/property_contexts
@@ -35,7 +35,6 @@ ro.vendor.btstack.                         u:object_r:bluetooth_prop:s0
 vendor.pts.                                u:object_r:bluetooth_prop:s0
 vendor.bt.pts.                             u:object_r:bluetooth_prop:s0
 vendor.bluetooth.                          u:object_r:bluetooth_prop:s0
-persist.vendor.camera.privapp.list         u:object_r:vendor_persist_camera_prop:s0
 
 #mm-parser
 vendor.mm.enable.qcom_parser       u:object_r:vendor_mm_parser_prop:s0


### PR DESCRIPTION
* This will be properly labeled after commit https://github.com/crdroidandroid/android_device_crdroid_sepolicy/commit/9b31e4a3c16d7ac41cb783d3ecd030168cf3bb1f#diff-fb75f11b89f79640db590bcabdd5ee7ab81f709c03e843c147728d299173828b